### PR TITLE
chore: Update Cargo.lock and Cargo.toml for Hiramu 0.1.8 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiramu"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-stream",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "hiramu"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 license = "MIT"
-description = "A Rust AI Engineering Toolbox"
+description = "A Rust AI Engineering Toolbox to Access Ollama, AWS Bedrock"
 repository = "https://github.com/raphaelmansuy/hiramu"
-keywords = ["api", "client", "async"]
+keywords = ["api", "client", "async","aws bedrock", "ollama"]
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To start using Hiramu in your Rust project, add the following to your `Cargo.tom
 
 ```toml
 [dependencies]
-hiramu = "0.1.7"
+hiramu = "0.1.8"
 ```
 
 ## Examples
@@ -94,6 +94,7 @@ async fn main() {
 ```rust
 use hiramu::ollama::ollama_client::OllamaClient;
 use hiramu::ollama::model::{GenerateRequest, GenerateRequestBuilder};
+use futures::stream::TryStreamExt;
 
 #[tokio::main]
 async fn main() {
@@ -132,7 +133,7 @@ async fn main() {
     let mut conversation_request = ConversationRequest::default();
     conversation_request
         .messages
-        .push(Message::new_user_message("Hello, Claude!"));
+        .push(Message::new_user_message("Hello, Claude!".to_owned()));
 
     let chat_options = ChatOptions::default()
         .with_temperature(0.7)

--- a/src/bedrock/models/claude/claude_client.rs
+++ b/src/bedrock/models/claude/claude_client.rs
@@ -5,6 +5,12 @@ use crate::bedrock::models::claude::claude_request_message::{
 use crate::bedrock::models::claude::error::ClaudeError;
 use futures::stream::Stream;
 use futures::TryStreamExt;
+use serde_json::Value;
+
+use super::claude_request_message::{
+    ContentBlockDelta, ContentBlockStart, ContentBlockStop, MessageDelta, MessageStart,
+    MessageStop, StreamResultData,
+};
 
 pub type ClaudeOptions = BedrockClientOptions;
 
@@ -47,25 +53,62 @@ impl ClaudeClient {
         &self,
         request: &ConversationRequest,
         options: &ChatOptions,
-    ) -> Result<impl Stream<Item = Result<StreamResult, ClaudeError>>, ClaudeError> {
+    ) -> Result<impl Stream<Item = Result<StreamResultData, ClaudeError>>, ClaudeError> {
         let model_id = options.model_id.to_string();
-        let payload = serde_json::to_value(request);
+        let payload = serde_json::to_value(request).map_err(|err| ClaudeError::Json(err))?;
 
-        let payload = match payload {
-            Ok(payload) => payload,
-            Err(err) => return Err(ClaudeError::Json(err)),
-        };
+        let response = self.client.generate_raw_stream(model_id, payload).await?;
 
-        let response = self.client.generate_raw_stream(model_id, payload).await;
+        let stream = response
+            .map_err(ClaudeError::from)
+            .and_then(|chunk| async move {
+                let stream_result = deserialize_stream_result(chunk)?;
+                Ok(stream_result)
+            });
 
-        let response = match response {
-            Ok(response) => response,
-            Err(err) => return Err(ClaudeError::from(err)),
-        };
+        Ok(stream)
+    }
+}
 
-        Ok(response
-            .map_ok(|value| serde_json::from_value(value).map_err(ClaudeError::Json))
-            .map_err(|err| ClaudeError::Unknown(err.to_string()))
-            .and_then(futures::future::ready))
+fn deserialize_stream_result(value: Value) -> Result<StreamResultData, ClaudeError> {
+    let stream_result: StreamResult = serde_json::from_value(value)
+        .map_err(|err| ClaudeError::Deserialization(err.to_string()))?;
+
+    match stream_result.result_type.as_str() {
+        "message_start" => {
+            let message_start: MessageStart = serde_json::from_value(stream_result.data)
+                .map_err(|err| ClaudeError::Deserialization(err.to_string()))?;
+            Ok(StreamResultData::MessageStart(message_start))
+        }
+        "content_block_start" => {
+            let content_block_start: ContentBlockStart = serde_json::from_value(stream_result.data)
+                .map_err(|err| ClaudeError::Deserialization(err.to_string()))?;
+            Ok(StreamResultData::ContentBlockStart(content_block_start))
+        }
+        "content_block_delta" => {
+            let content_block_delta: ContentBlockDelta = serde_json::from_value(stream_result.data)
+                .map_err(|err| ClaudeError::Deserialization(err.to_string()))?;
+            Ok(StreamResultData::ContentBlockDelta(content_block_delta))
+        }
+        "content_block_stop" => {
+            let content_block_stop: ContentBlockStop =
+                serde_json::from_value(stream_result.data)
+                    .map_err(|err| ClaudeError::Deserialization(err.to_string()))?;
+            Ok(StreamResultData::ContentBlockStop(content_block_stop))
+        }
+        "message_delta" => {
+            let message_delta: MessageDelta = serde_json::from_value(stream_result.data)
+                .map_err(|err| ClaudeError::Deserialization(err.to_string()))?;
+            Ok(StreamResultData::MessageDelta(message_delta))
+        }
+        "message_stop" => {
+            let message_stop: MessageStop = serde_json::from_value(stream_result.data)
+                .map_err(|err| ClaudeError::Deserialization(err.to_string()))?;
+            Ok(StreamResultData::MessageStop(message_stop))
+        }
+        _ => Err(ClaudeError::Deserialization(format!(
+            "Unknown StreamResult type: {}",
+            stream_result.result_type
+        ))),
     }
 }

--- a/src/bedrock/models/claude/claude_request_message.rs
+++ b/src/bedrock/models/claude/claude_request_message.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use super::ClaudeError;
+
 pub struct ChatOptions {
     pub model_id: String,
     pub temperature: Option<f32>,
@@ -200,6 +202,17 @@ pub struct StreamResult {
     pub result_type: String,
     #[serde(flatten)]
     pub data: serde_json::Value,
+}
+
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum StreamResultData {
+    MessageStart(MessageStart),
+    ContentBlockStart(ContentBlockStart),
+    ContentBlockDelta(ContentBlockDelta),
+    ContentBlockStop(ContentBlockStop),
+    MessageDelta(MessageDelta),
+    MessageStop(MessageStop),
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/bedrock/models/claude/error.rs
+++ b/src/bedrock/models/claude/error.rs
@@ -23,4 +23,7 @@ pub enum ClaudeError {
 
     #[error("Unknown error: {0}")]
     Unknown(String),
+
+    #[error("Deserialization error: {0}")]
+    Deserialization(String),
 }


### PR DESCRIPTION
feat: Add support for streaming results in ClaudeClient
docs: Update README with examples for using ClaudeClient

This commit includes the following changes:

1. Updated the Cargo.lock and Cargo.toml files to reflect the new version 0.1.8 of the Hiramu crate.
2. Implemented the ability to stream results in the ClaudeClient, allowing for more efficient and responsive handling of large responses.
3. Updated the README file with examples demonstrating the usage of the ClaudeClient and its streaming capabilities.